### PR TITLE
tunnels.conf: ignore pfs group if pfs is disabled

### DIFF
--- a/root/etc/e-smith/templates/etc/ipsec.d/tunnels.conf/20net2net
+++ b/root/etc/e-smith/templates/etc/ipsec.d/tunnels.conf/20net2net
@@ -43,11 +43,10 @@
         }
 
         if ($esp eq 'custom') {
+            # Set PFS group only if PFS is disabled
+            $props{'phase2alg'} = $props{'espcipher'} .'-'.  $props{'esphash'};
             if ($props{'pfs'} eq 'yes') {
-                $props{'phase2alg'} = $props{'espcipher'} .'-'.  $props{'esphash'} .';'. $props{'esppfsgroup'};
-            } else {
-                # Do not set PFS groups if PFS is disabled
-                $props{'phase2alg'} = $props{'espcipher'} .'-'.  $props{'esphash'};
+                $props{'phase2alg'} .= ';'. $props{'esppfsgroup'};
             }
             $t = $props{'salifetime'} || "3600";
             $props{'salifetime'} = $t .'s';

--- a/root/etc/e-smith/templates/etc/ipsec.d/tunnels.conf/20net2net
+++ b/root/etc/e-smith/templates/etc/ipsec.d/tunnels.conf/20net2net
@@ -43,7 +43,12 @@
         }
 
         if ($esp eq 'custom') {
-            $props{'phase2alg'} = $props{'espcipher'} .'-'.  $props{'esphash'} .';'. $props{'esppfsgroup'};
+            if ($props{'pfs'} eq 'yes') {
+                $props{'phase2alg'} = $props{'espcipher'} .'-'.  $props{'esphash'} .';'. $props{'esppfsgroup'};
+            } else {
+                # Do not set PFS groups if PFS is disabled
+                $props{'phase2alg'} = $props{'espcipher'} .'-'.  $props{'esphash'};;
+            }
             $t = $props{'salifetime'} || "3600";
             $props{'salifetime'} = $t .'s';
         } else {

--- a/root/etc/e-smith/templates/etc/ipsec.d/tunnels.conf/20net2net
+++ b/root/etc/e-smith/templates/etc/ipsec.d/tunnels.conf/20net2net
@@ -47,7 +47,7 @@
                 $props{'phase2alg'} = $props{'espcipher'} .'-'.  $props{'esphash'} .';'. $props{'esppfsgroup'};
             } else {
                 # Do not set PFS groups if PFS is disabled
-                $props{'phase2alg'} = $props{'espcipher'} .'-'.  $props{'esphash'};;
+                $props{'phase2alg'} = $props{'espcipher'} .'-'.  $props{'esphash'};
             }
             $t = $props{'salifetime'} || "3600";
             $props{'salifetime'} = $t .'s';


### PR DESCRIPTION
Avoid errors like:

 Failed to add connection "tunnel/1x1", esp="3des-md5;modp1024" is invalid: ESP DH algorithm MODP102
 4 is invalid as PFS policy is disabled

NethServer/dev#5696