### PR TITLE
Force left to %defaultroute for DHCP

### DIFF
--- a/root/etc/e-smith/templates/etc/ipsec.d/tunnels.conf/20net2net
+++ b/root/etc/e-smith/templates/etc/ipsec.d/tunnels.conf/20net2net
@@ -76,7 +76,12 @@
         # if no IP address has been found, fallback to %defaultroute
         # %defaultroute will work only for non-multiwan environment
         my $iname = substr($props{'left'},1);
-        $props{'left'} = $ndb->get_prop($iname, 'ipaddr') || "%defaultroute";
+        my $bootproto = $ndb->get_prop($iname, 'bootproto');
+        if ($bootproto eq 'dhcp') {
+            $props{'left'} = "%defaultroute";
+        } else {
+            $props{'left'} = $ndb->get_prop($iname, 'ipaddr') || "%defaultroute";
+        }
 
         # remove empty options
         for (keys %props) {


### PR DESCRIPTION
Do not use the IP if the newtwork interface is configured with DHCP.
Previous code would use dirty IP value if the red interface was changed
from static to dynamic.

NethServer/dev#6096