### PR TITLE
ipsec CLI must use the correct tunnel name

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-ipsec-tunnels-edit
+++ b/root/etc/e-smith/events/actions/nethserver-ipsec-tunnels-edit
@@ -20,7 +20,7 @@
 
 event=$1
 action=$2
-tunnel=$3
+tunnel="${3}_ipsec-tunnel"
 
 if [ -z "$event" ]; then
     exit 0


### PR DESCRIPTION
when you try to delete an ipsec  tunnel in cockpit you use an action  `/etc/e-smith/events/actions/nethserver-ipsec-tunnels-edit` throught an event but we push the key name to the action. IPSEC expects that tunnel is named `$KEY_tunnel- ipsec`

you can see how many tunnel are up and (dis)connected with `ipsec status`

https://github.com/NethServer/dev/issues/6389