### PR TITLE
Delete conntrack on disable/delete action

### DIFF
--- a/root/etc/e-smith/events/actions/nethserver-ipsec-tunnels-edit
+++ b/root/etc/e-smith/events/actions/nethserver-ipsec-tunnels-edit
@@ -33,18 +33,14 @@ if [ "$action" == "create" ]; then
 elif [ "$action" == "modify" ]; then
     /usr/sbin/ipsec auto --delete "$tunnel"
     /usr/sbin/ipsec auto --start "$tunnel"
-elif [ "$action" == "delete" ] || [ "$action" == "disable" ]; then
+elif [ "$action" == "delete" ]; then
     /usr/sbin/ipsec auto --delete "$tunnel"
+    ret=$?
 
-    # Destroy a non existing connexion with conntrack leads to stderr error
-    TEST500=$(/usr/sbin/conntrack -L  -d  $remoteIP --proto UDP --sport 500 --dport 500)
-    if [[ $TEST500 != '' ]];then
-        /usr/sbin/conntrack -D  -d  $remoteIP --proto UDP --sport 500 --dport 500
+    if [ ! -z "$remoteIP" ]; then
+        /usr/sbin/conntrack -D  -d  $remoteIP --proto UDP --sport 500 --dport 500 2>/dev/null
+        /usr/sbin/conntrack -D  -d  $remoteIP --proto UDP --sport 4500 --dport 4500 2>/dev/null
     fi
 
-    TEST4500=$(/usr/sbin/conntrack -L  -d  $remoteIP --proto UDP --sport 4500 --dport 4500)
-    if [[ $TEST4500 != '' ]];then
-        /usr/sbin/conntrack -D  -d  $remoteIP --proto UDP --sport 4500 --dport 4500
-    fi
-
+    exit $ret
 fi

--- a/root/etc/e-smith/events/actions/nethserver-ipsec-tunnels-edit
+++ b/root/etc/e-smith/events/actions/nethserver-ipsec-tunnels-edit
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright (C) 2019 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
@@ -21,16 +22,29 @@
 event=$1
 action=$2
 tunnel="${3}_ipsec-tunnel"
+remoteIP=$4
 
 if [ -z "$event" ]; then
     exit 0
 fi
 
 if [ "$action" == "create" ]; then
-    ipsec auto --start "$tunnel"
+    /usr/sbin/ipsec auto --start "$tunnel"
 elif [ "$action" == "modify" ]; then
-    ipsec auto --delete "$tunnel"
-    ipsec auto --start "$tunnel"
-elif [ "$action" == "delete" ]; then
-    ipsec auto --delete "$tunnel"
+    /usr/sbin/ipsec auto --delete "$tunnel"
+    /usr/sbin/ipsec auto --start "$tunnel"
+elif [ "$action" == "delete" ] || [ "$action" == "disable" ]; then
+    /usr/sbin/ipsec auto --delete "$tunnel"
+
+    # Destroy a non existing connexion with conntrack leads to stderr error
+    TEST500=$(/usr/sbin/conntrack -L  -d  $remoteIP --proto UDP --sport 500 --dport 500)
+    if [[ $TEST500 != '' ]];then
+        /usr/sbin/conntrack -D  -d  $remoteIP --proto UDP --sport 500 --dport 500
+    fi
+
+    TEST4500=$(/usr/sbin/conntrack -L  -d  $remoteIP --proto UDP --sport 4500 --dport 4500)
+    if [[ $TEST4500 != '' ]];then
+        /usr/sbin/conntrack -D  -d  $remoteIP --proto UDP --sport 4500 --dport 4500
+    fi
+
 fi

--- a/root/etc/systemd/system/ipsec.service.d/nethserver.conf
+++ b/root/etc/systemd/system/ipsec.service.d/nethserver.conf
@@ -1,0 +1,3 @@
+[Service]
+# on ipsec stop delete all conntrack connections
+ExecStopPost=/usr/libexec/nethserver/nethserver-ipsec-tunnels-delete-conntrack

--- a/root/usr/libexec/nethserver/nethserver-ipsec-tunnels-delete-conntrack
+++ b/root/usr/libexec/nethserver/nethserver-ipsec-tunnels-delete-conntrack
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+#
+# Copyright (C) 2021 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+#
+# Delete conntrack connection on ipsec service stop for disabled vpn
+#
+
+use warnings;
+use strict;
+
+use esmith::NetworksDB;
+my $vdb = esmith::NetworksDB->open_ro('vpn');
+
+foreach my $tunnel ($vdb->get_all_by_prop('type' => 'ipsec-tunnel')) {
+    my $status = $tunnel->prop('status') || 'disabled';
+    next if ($status eq 'enabled');
+    next if (!defined($tunnel->prop('right')));
+    system("/usr/sbin/conntrack","-D","-d",$tunnel->prop('right'),"--proto","UDP","--sport","500","--dport","500","2>/dev/null");
+    system("/usr/sbin/conntrack","-D","-d",$tunnel->prop('right'),"--proto","UDP","--sport","4500","--dport","4500","2>/dev/null");
+}


### PR DESCRIPTION
When you delete or disable an IPSEC tunnel the conntrack connection of the remote IP are not deleted, this try to fix a multiwan issue  when one red wan might fail down, the vpn tunnel uses the another red wan.

linked to https://github.com/NethServer/nethserver-vpn-ui/pull/46

https://github.com/NethServer/dev/issues/6393